### PR TITLE
Return solar data from forecast.io

### DIFF
--- a/R/Rforecastio.R
+++ b/R/Rforecastio.R
@@ -51,12 +51,13 @@ require(plyr)
 fio.forecast <- function(api.key, latitude, longitude, for.time, time.formatter=as.POSIXlt, ...) {
 
   # using RCurl's getURLContent() since it fully supports http or https
+  # using RCurl's getURLContent() since it fully supports http or https
   if (missing(for.time)) {
-    fio.json <- getURLContent(url=sprintf("https://api.forecast.io/forecast/%s/%s,%s",
-                                      api.key, latitude, longitude), ...)
+    fio.json <- getURLContent(url = paste(sprintf("https://api.forecast.io/forecast/%s/%s,%s",
+                                      api.key, latitude, longitude), "?solar", sep = "/"), ...)
   } else {
-    fio.json <- getURLContent(url=sprintf("https://api.forecast.io/forecast/%s/%s,%s,%d",
-                                      api.key, latitude, longitude, for.time), ...)
+    fio.json <- getURLContent(url = paste(sprintf("https://api.forecast.io/forecast/%s/%s,%s",
+                                                  api.key, latitude, longitude), "?solar", for.time, sep = "/"), ...)
   }
 
   if (class(fio.json) == "raw") {


### PR DESCRIPTION
This is an experimental feature. I am not familiar with json and have been having trouble getting the solar radiation into the dataframe (because it is a list rather than numeric like other values returned). But this is a start (albiet a hacky one):

``` r
  hourly <- lapply(fio$hourly$data, unlist)
  solar <- lapply(hourly, function(x) x[grepl("solar", names(x))])
  solar.df <- suppressWarnings(do.call("rbind", sapply(solar, function(x) if(length(x) > 0){as.numeric(x)}else{rep(0,5)})))

  colnames(solar.df) <- c("azimuth", "altitude", "dni", "ghi", "dhi", "etr")
  lapply(fio$hourly$data, function(x) ifelse(!is.null(x$solar), x$solar, x$solar))
```
